### PR TITLE
Move fakerphp/faker to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
         "php": "^8.2",
         "laravel/fortify": "^1.27",
         "laravel/framework": "^12.0",
-        "laravel/tinker": "^2.10.1",
-        "fakerphp/faker": "^1.23"
+        "laravel/tinker": "^2.10.1"
     },
     "require-dev": {
+        "fakerphp/faker": "^1.23",
         "laravel/pail": "^1.2.2",
         "laravel/pint": "^1.13",
         "laravel/sail": "^1.41",


### PR DESCRIPTION
Move `fakerphp/faker` from `require` to `require-dev` in `composer.json` to correctly classify it as a development-only dependency.